### PR TITLE
Possible to disable entity shape render

### DIFF
--- a/locale/en/PipeVisualizer.cfg
+++ b/locale/en/PipeVisualizer.cfg
@@ -16,6 +16,8 @@ pv-entities-per-tick=Higher numbers will increase UPS impact, particularly when 
 [mod-setting-name]
 pv-entities-per-tick=Entities per tick
 pv-overlay-opacity=Overlay opacity
+pv-highlight-entities-overlay=Highlight entity on overlay mode
+pv-highlight-entities-mouse-hover=Highlight entity on mouse over
 
 [shortcut-name]
 pv-toggle-mouseover=Toggle mouse-over pipe visualizer

--- a/scripts/iterator.lua
+++ b/scripts/iterator.lua
@@ -72,6 +72,7 @@ local function request(entity, player_index, in_overlay, from_hover)
     self = {
       entities = {},
       in_overlay = in_overlay,
+      from_hover = from_hover,
       in_queue = {},
       next_color_index = 0,
       player_index = player_index,

--- a/scripts/iterator.lua
+++ b/scripts/iterator.lua
@@ -72,7 +72,6 @@ local function request(entity, player_index, in_overlay, from_hover)
     self = {
       entities = {},
       in_overlay = in_overlay,
-      from_hover = from_hover,
       in_queue = {},
       next_color_index = 0,
       player_index = player_index,

--- a/scripts/renderer.lua
+++ b/scripts/renderer.lua
@@ -82,7 +82,10 @@ function renderer.draw(it, entity_data)
     local playerSettings = settings.get_player_settings(it.player_index)
     local showEntOverlay = playerSettings["pv-highlight-entities-overlay"].value
     local showEntMouseOver = playerSettings["pv-highlight-entities-mouse-hover"].value
-    if (not it.from_hover and showEntOverlay) or (it.from_hover and showEntMouseOver) then
+    local mouseover_enabled = global.mouseover_enabled[it.player_index]
+   
+    if (not mouseover_enabled and showEntOverlay) or (mouseover_enabled and showEntMouseOver) then
+   
       entity_data.shape = draw_sprite({
         sprite = "pv-entity-box",
         tint = default_color,

--- a/settings.lua
+++ b/settings.lua
@@ -14,4 +14,16 @@ data:extend({
     default_value = 30,
     minimum_value = 1,
   },
+  {
+    type = "bool-setting",
+    name = "pv-highlight-entities-overlay",
+    setting_type = "runtime-per-user",
+    default_value = true,
+  },
+  {
+    type = "bool-setting",
+    name = "pv-highlight-entities-mouse-hover",
+    setting_type = "runtime-per-user",
+    default_value = true,
+  },
 })


### PR DESCRIPTION
With these changes, user has 2 new options, so he can disable entity shape render for the mouse hover and/or for the overlay.

